### PR TITLE
Fix: Player alarm not enabled by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/PlayerAlarm/PlayerAlarmPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/PlayerAlarm/PlayerAlarmPlugin.java
@@ -19,7 +19,11 @@
  import org.slf4j.Logger;
  import org.slf4j.LoggerFactory;
  
- @PluginDescriptor(name = "<html>[<font color=#ff00ff>§</font>] " + "Player Alarm")
+ @PluginDescriptor(
+         name = "<html>[<font color=#ff00ff>§</font>] " + "Player Alarm",
+         enabledByDefault = false
+
+ )
  public class PlayerAlarmPlugin extends Plugin {
    private static final Logger log = LoggerFactory.getLogger(PlayerAlarmPlugin.class);
  


### PR DESCRIPTION
With some of the recent plugin additions, I was in lumbridge & found this was enabled by default with sound playing very loud, this should not be something that is on by default.