### PR TITLE
Update: More Bank Location changes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/bank/enums/BankLocation.java
@@ -69,7 +69,8 @@ public enum BankLocation {
     PISCARILIUS(new WorldPoint(1803, 3790, 0)),
     PORT_KHAZARD(new WorldPoint(2664, 3161, 0)),
     PRIFDDINAS(new WorldPoint(3257, 6106, 0)),
-    ROGUES_DEN(new WorldPoint(3043, 4973, 1)),
+    ROGUES_DEN_EMERALD_BENEDICT(new WorldPoint(3043, 4973, 1)),
+    ROGUES_DEN_CHEST(new WorldPoint(3040, 4969, 1)),
     RUINS_OF_UNKAH(new WorldPoint(3156, 2835, 0)),
     SHANTY_PASS(new WorldPoint(3308, 3120, 0)),
     SHAYZIEN_BANK(new WorldPoint(1488, 3592, 0)),
@@ -87,6 +88,7 @@ public enum BankLocation {
     VINERY_BANK(new WorldPoint(1809, 3566, 0)),
     VOLCANO_BANK(new WorldPoint(3819, 3809, 0)),
     WINTERTODT(new WorldPoint(1640, 3944, 0)),
+    WARRIORS_GUILD(new WorldPoint(2843, 3542, 0)),
     WOODCUTTING_GUILD(new WorldPoint(1591, 3479, 0)),
     YANILLE(new WorldPoint(2613, 3093, 0)),
     ZANARIS(new WorldPoint(2383, 4458, 0)),
@@ -99,19 +101,38 @@ public enum BankLocation {
         switch (this){
             case CRAFTING_GUILD:
                 if (hasLineOfSight) return true;
-                return Microbot.getClient().getRealSkillLevel(Skill.CRAFTING) >= 40
+                return Rs2Player.getRealSkillLevel(Skill.CRAFTING) >= 40
                         && (Rs2Equipment.isWearing("brown apron") || Rs2Equipment.isWearing("golden apron"));
             case LUMBRIDGE_BASEMENT:
                 return Rs2Player.getQuestState(Quest.RECIPE_FOR_DISASTER__ANOTHER_COOKS_QUEST) == QuestState.FINISHED;
             case COOKS_GUILD:
                 if (hasLineOfSight && Rs2Player.isMember()) return true;
-                boolean hasVarrockHardDiary = Microbot.getClientThread().runOnClientThread(() -> Microbot.getClient().getVarbitValue(Varbits.DIARY_VARROCK_HARD) == 1);
-                boolean hasMaxedCooking = Microbot.getClient().getRealSkillLevel(Skill.COOKING) >= 99;
+                boolean hasVarrockHardDiary = Microbot.getVarbitValue(Varbits.DIARY_VARROCK_HARD)  == 1;
+                boolean hasMaxedCooking = Rs2Player.getRealSkillLevel(Skill.COOKING) >= 99;
                 boolean isWearingCooksGuild = Rs2Equipment.isWearing("chef's hat") ||
                         (Rs2Equipment.isWearing("cooking cape") || Rs2Equipment.isWearing("cooking hood")) ||
                         (Rs2Equipment.isWearing("max cape") || Rs2Equipment.isWearing("max hood")) ||
                         (Rs2Equipment.isWearing("varrock armour 3") || Rs2Equipment.isWearing("varrock armour 4"));
                 return Rs2Player.isMember() && isWearingCooksGuild && (hasVarrockHardDiary || hasMaxedCooking);
+            case WARRIORS_GUILD:
+                if (hasLineOfSight) return true;
+                return (Rs2Player.getRealSkillLevel(Skill.ATTACK) >= 99 || Rs2Player.getRealSkillLevel(Skill.STRENGTH) >= 99) ||
+                        (Rs2Player.getRealSkillLevel(Skill.ATTACK) + Rs2Player.getRealSkillLevel(Skill.STRENGTH) >= 130);
+            case WOODCUTTING_GUILD:
+                if (hasLineOfSight && Rs2Player.isMember()) return true;
+                return Rs2Player.isMember() && Microbot.getClient().getBoostedSkillLevel(Skill.WOODCUTTING) >= 60;
+            case FARMING_GUILD:
+                if (hasLineOfSight && Rs2Player.isMember()) return true;
+                return Rs2Player.isMember() && Rs2Player.getBoostedSkillLevel(Skill.FARMING) >= 45;
+            case MINING_GUILD:
+                if (hasLineOfSight && Rs2Player.isMember()) return true;
+                return Rs2Player.isMember() && Rs2Player.getBoostedSkillLevel(Skill.MINING) >= 60;
+            case FISHING_GUILD:
+                if (hasLineOfSight && Rs2Player.isMember()) return true;
+                return Rs2Player.isMember() && Rs2Player.getBoostedSkillLevel(Skill.FISHING) >= 68;
+            case HUNTERS_GUILD:
+                if (hasLineOfSight && Rs2Player.isMember()) return true;
+                return Rs2Player.isMember() && Rs2Player.getRealSkillLevel(Skill.HUNTER) >= 46;
             default:
                 return true;
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/player/Rs2Player.java
@@ -309,4 +309,14 @@ public class Rs2Player {
         Client client = Microbot.getClient();
         return Microbot.getClientThread().runOnClientThread(() -> quest.getState(client));
     }
+
+    public static int getRealSkillLevel(Skill skill){
+        Client client = Microbot.getClient();
+        return client.getRealSkillLevel(skill);
+    }
+
+    public static int getBoostedSkillLevel(Skill skill){
+        Client client = Microbot.getClient();
+        return client.getBoostedSkillLevel(skill);
+    }
 }


### PR DESCRIPTION
I have added some more checks for the hasRequirements to some of the skilling guild banks that are listed in the bank locations to ensure that players aren't sent somewhere they can't access.

I have also added the Rouge's Den Chest along side of renaming the existing Rouge's Den Bank to Emerald Benedict.

With this, I have also created two new methods inside of Rs2Player called getRealSkillLevel & getBoostedSkillLevel, not really needed but does save calling an additional getter when calling for these methods.

The only guild that has a bank that I am missing is Legends Guild, if we could add that to this as well. the check would be as follows.

```
case LEGENDS_GUILD:
    if (hasLineOfSight) return true;
    return Rs2Player.getQuestState(Quest.LEGENDS_QUEST) == QuestState.FINISHED;
```